### PR TITLE
createServer wip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   only-doc-changes:
-    if: github.repository == 'redwoodjs/redwood'
+    # if: github.repository == 'redwoodjs/redwood'
     name: 📖 Only doc changes?
     runs-on: ubuntu-latest
     outputs:

--- a/packages/api-server/dist.test.ts
+++ b/packages/api-server/dist.test.ts
@@ -71,6 +71,7 @@ describe('dist', () => {
             "type": "string",
           },
         },
+        "createServer": [Function],
         "webCliOptions": {
           "apiHost": {
             "alias": "api-host",

--- a/packages/api-server/package.json
+++ b/packages/api-server/package.json
@@ -59,6 +59,7 @@
     "@types/yargs": "17.0.24",
     "aws-lambda": "1.0.7",
     "jest": "29.7.0",
+    "pino-abstract-transport": "1.1.0",
     "typescript": "5.2.2"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"

--- a/packages/api-server/src/__tests__/createServer.test.ts
+++ b/packages/api-server/src/__tests__/createServer.test.ts
@@ -53,7 +53,7 @@ describe('createServer', () => {
     expect(console.warn.mock.calls[0][0]).toMatchInlineSnapshot(`
       "[33m[39m
       [33mIgnoring \`config\` and \`configureServer\` in api/server.config.js.[39m
-      [33mMigrate them to api/src/server.{ts,js}[39m
+      [33mMigrate them to api/src/server.{ts,js}:[39m
       [33m[39m
       [33m\`\`\`js title="api/src/server.{ts,js}"[39m
       [33m// Pass your config to \`createServer\`[39m
@@ -68,8 +68,8 @@ describe('createServer', () => {
     `)
   })
 
-  it('`routePrefix` prefixes all routes', async () => {
-    const server = await createServer({ routePrefix: '/api' })
+  it('`apiRootPath` prefixes all routes', async () => {
+    const server = await createServer({ apiRootPath: '/api' })
 
     await server.listen({
       port: 8910,
@@ -126,15 +126,13 @@ describe('createServer', () => {
 
     const lastCallIndex = console.log.mock.calls.length - 1
 
-    expect(console.log.mock.calls[lastCallIndex][0]).toMatch(
-      /Done importing in \d+ ms/
-    )
+    expect(console.log.mock.calls[lastCallIndex][0]).toMatch(/Listening on/)
 
     // `console.warn` will be used if there's a `server.config.js` file.
     expect(console.warn.mock.calls[0][0]).toMatchInlineSnapshot(`
       "[33m[39m
       [33mIgnoring \`config\` and \`configureServer\` in api/server.config.js.[39m
-      [33mMigrate them to api/src/server.{ts,js}[39m
+      [33mMigrate them to api/src/server.{ts,js}:[39m
       [33m[39m
       [33m\`\`\`js title="api/src/server.{ts,js}"[39m
       [33m// Pass your config to \`createServer\`[39m
@@ -177,10 +175,6 @@ describe('createServer', () => {
       level: 30,
       msg: 'Server listening at http://127.0.0.1:8910',
     })
-    expect(loggerLogs[4]).toMatchObject({
-      level: 30,
-      msg: 'Listening on [35mhttp://::1:8910/[39m',
-    })
   })
 
   describe('`server.start`', () => {
@@ -213,7 +207,7 @@ describe('resolveCreateServerOptions', () => {
     const resolvedOptions = resolveCreateServerOptions()
 
     expect(resolvedOptions).toEqual({
-      routePrefix: DEFAULT_CREATE_SERVER_OPTIONS.routePrefix,
+      apiRootPath: DEFAULT_CREATE_SERVER_OPTIONS.apiRootPath,
       fastifyServerOptions: {
         requestTimeout:
           DEFAULT_CREATE_SERVER_OPTIONS.fastifyServerOptions.requestTimeout,
@@ -222,25 +216,25 @@ describe('resolveCreateServerOptions', () => {
     })
   })
 
-  it('ensures `routePrefix` has slashes', () => {
+  it('ensures `apiRootPath` has slashes', () => {
     const expected = '/v1/'
 
     expect(
       resolveCreateServerOptions({
-        routePrefix: 'v1',
-      }).routePrefix
+        apiRootPath: 'v1',
+      }).apiRootPath
     ).toEqual(expected)
 
     expect(
       resolveCreateServerOptions({
-        routePrefix: '/v1',
-      }).routePrefix
+        apiRootPath: '/v1',
+      }).apiRootPath
     ).toEqual(expected)
 
     expect(
       resolveCreateServerOptions({
-        routePrefix: 'v1/',
-      }).routePrefix
+        apiRootPath: 'v1/',
+      }).apiRootPath
     ).toEqual(expected)
   })
 

--- a/packages/api-server/src/__tests__/createServer.test.ts
+++ b/packages/api-server/src/__tests__/createServer.test.ts
@@ -1,0 +1,310 @@
+import path from 'path'
+
+import pino from 'pino'
+import build from 'pino-abstract-transport'
+
+import { getConfig } from '@redwoodjs/project-config'
+
+import {
+  createServer,
+  resolveCreateServerOptions,
+  DEFAULT_CREATE_SERVER_OPTIONS,
+  parseArgs,
+} from '../createServer'
+
+// Set up RWJS_CWD.
+let original_RWJS_CWD
+
+beforeAll(() => {
+  original_RWJS_CWD = process.env.RWJS_CWD
+  process.env.RWJS_CWD = path.join(__dirname, './fixtures/redwood-app')
+})
+
+afterAll(() => {
+  process.env.RWJS_CWD = original_RWJS_CWD
+})
+
+describe('createServer', () => {
+  // Create a server for most tests. Some that test initialization create their own.
+  let server
+
+  beforeAll(async () => {
+    server = await createServer()
+  })
+
+  afterAll(async () => {
+    await server?.close()
+  })
+
+  it('serves functions', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/hello',
+    })
+
+    expect(res.json()).toEqual({ data: 'hello function' })
+  })
+
+  it('warns about server.config.js', async () => {
+    console.warn = jest.fn()
+
+    await createServer()
+
+    expect(console.warn.mock.calls[0][0]).toMatchInlineSnapshot(`
+      "[33m[39m
+      [33mIgnoring \`config\` and \`configureServer\` in api/server.config.js.[39m
+      [33mMigrate them to api/src/server.{ts,js}[39m
+      [33m[39m
+      [33m\`\`\`js title="api/src/server.{ts,js}"[39m
+      [33m// Pass your config to \`createServer\`[39m
+      [33mconst server = createServer({[39m
+      [33m  fastifyServerOptions: myFastifyConfig[39m
+      [33m})[39m
+      [33m[39m
+      [33m// Then inline your \`configureFastify\` logic:[39m
+      [33mserver.register(myFastifyPlugin)[39m
+      [33m\`\`\`[39m
+      [33m[39m"
+    `)
+  })
+
+  it('`routePrefix` prefixes all routes', async () => {
+    const server = await createServer({ routePrefix: '/api' })
+
+    await server.listen({
+      port: 8910,
+    })
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/hello',
+    })
+
+    expect(res.json()).toEqual({ data: 'hello function' })
+
+    await server.close()
+  })
+
+  // Moving config loading up makes this trickier to test.
+  it.skip('loads env files if not already loaded', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/env',
+    })
+
+    expect(res.json()).toEqual({ data: '42' })
+  })
+
+  // We use `console.log` and `.warn` to output some things.
+  // Meanwhile, the server gets a logger that may not output to the same place
+  // The server's logger also seems to output things out of order.
+  it("doesn't handle logs consistently", async () => {
+    console.log = jest.fn()
+    console.warn = jest.fn()
+
+    // Here we create a logger that outputs to an array.
+    const loggerLogs = []
+    const stream = build(async (source) => {
+      for await (const obj of source) {
+        loggerLogs.push(obj)
+      }
+    })
+    const logger = pino(stream)
+
+    // Generate some logs.
+    const server = await createServer({ logger })
+    const res = await server.inject({
+      method: 'GET',
+      url: '/hello',
+    })
+    expect(res.json()).toEqual({ data: 'hello function' })
+    await server.listen({ port: 8910 })
+    await server.close()
+
+    // We expect console log to be called with `withFunctions` logs.
+    expect(console.log.mock.calls[0][0]).toMatch(/Importing Server Functions/)
+
+    const lastCallIndex = console.log.mock.calls.length - 1
+
+    expect(console.log.mock.calls[lastCallIndex][0]).toMatch(
+      /Done importing in \d+ ms/
+    )
+
+    // `console.warn` will be used if there's a `server.config.js` file.
+    expect(console.warn.mock.calls[0][0]).toMatchInlineSnapshot(`
+      "[33m[39m
+      [33mIgnoring \`config\` and \`configureServer\` in api/server.config.js.[39m
+      [33mMigrate them to api/src/server.{ts,js}[39m
+      [33m[39m
+      [33m\`\`\`js title="api/src/server.{ts,js}"[39m
+      [33m// Pass your config to \`createServer\`[39m
+      [33mconst server = createServer({[39m
+      [33m  fastifyServerOptions: myFastifyConfig[39m
+      [33m})[39m
+      [33m[39m
+      [33m// Then inline your \`configureFastify\` logic:[39m
+      [33mserver.register(myFastifyPlugin)[39m
+      [33m\`\`\`[39m
+      [33m[39m"
+    `)
+
+    // Finally, the logger. Notice how the request/response logs come before the "server is listening..." logs.
+    expect(loggerLogs[0]).toMatchObject({
+      reqId: 'req-1',
+      level: 30,
+      msg: 'incoming request',
+      req: {
+        hostname: 'localhost:80',
+        method: 'GET',
+        remoteAddress: '127.0.0.1',
+        url: '/hello',
+      },
+    })
+    expect(loggerLogs[1]).toMatchObject({
+      reqId: 'req-1',
+      level: 30,
+      msg: 'request completed',
+      res: {
+        statusCode: 200,
+      },
+    })
+
+    expect(loggerLogs[2]).toMatchObject({
+      level: 30,
+      msg: 'Server listening at http://[::1]:8910',
+    })
+    expect(loggerLogs[3]).toMatchObject({
+      level: 30,
+      msg: 'Server listening at http://127.0.0.1:8910',
+    })
+    expect(loggerLogs[4]).toMatchObject({
+      level: 30,
+      msg: 'Listening on [35mhttp://::1:8910/[39m',
+    })
+  })
+
+  describe('`server.start`', () => {
+    it('starts the server using [api].port in redwood.toml if none is specified', async () => {
+      const server = await createServer()
+      await server.start()
+
+      expect(server.server.address().port).toBe(getConfig().api.port)
+
+      await server.close()
+    })
+
+    it('the `REDWOOD_API_PORT` env var takes precedence over [api].port', async () => {
+      process.env.REDWOOD_API_PORT = '8920'
+
+      const server = await createServer()
+      await server.start()
+
+      expect(server.server.address().port).toBe(+process.env.REDWOOD_API_PORT)
+
+      await server.close()
+
+      delete process.env.REDWOOD_API_PORT
+    })
+  })
+})
+
+describe('resolveCreateServerOptions', () => {
+  it('nothing passed', () => {
+    const resolvedOptions = resolveCreateServerOptions()
+
+    expect(resolvedOptions).toEqual({
+      routePrefix: DEFAULT_CREATE_SERVER_OPTIONS.routePrefix,
+      fastifyServerOptions: {
+        requestTimeout:
+          DEFAULT_CREATE_SERVER_OPTIONS.fastifyServerOptions.requestTimeout,
+        logger: DEFAULT_CREATE_SERVER_OPTIONS.logger,
+      },
+    })
+  })
+
+  it('ensures `routePrefix` has slashes', () => {
+    const expected = '/v1/'
+
+    expect(
+      resolveCreateServerOptions({
+        routePrefix: 'v1',
+      }).routePrefix
+    ).toEqual(expected)
+
+    expect(
+      resolveCreateServerOptions({
+        routePrefix: '/v1',
+      }).routePrefix
+    ).toEqual(expected)
+
+    expect(
+      resolveCreateServerOptions({
+        routePrefix: 'v1/',
+      }).routePrefix
+    ).toEqual(expected)
+  })
+
+  it('moves `logger` to `fastifyServerOptions.logger`', () => {
+    const resolvedOptions = resolveCreateServerOptions({
+      logger: { level: 'info' },
+    })
+
+    expect(resolvedOptions).toMatchObject({
+      fastifyServerOptions: {
+        logger: { level: 'info' },
+      },
+    })
+  })
+
+  it('`logger` overwrites `fastifyServerOptions.logger`', () => {
+    const resolvedOptions = resolveCreateServerOptions({
+      logger: false,
+      fastifyServerOptions: {
+        // @ts-expect-error this is invalid TS but valid JS
+        logger: true,
+      },
+    })
+
+    expect(resolvedOptions).toMatchObject({
+      fastifyServerOptions: {
+        logger: false,
+      },
+    })
+  })
+
+  it('`DEFAULT_CREATE_SERVER_OPTIONS` overwrites `fastifyServerOptions.logger`', () => {
+    const resolvedOptions = resolveCreateServerOptions({
+      fastifyServerOptions: {
+        // @ts-expect-error this is invalid TS but valid JS
+        logger: true,
+      },
+    })
+
+    expect(resolvedOptions).toMatchObject({
+      fastifyServerOptions: {
+        logger: DEFAULT_CREATE_SERVER_OPTIONS.logger,
+      },
+    })
+  })
+})
+
+describe('parseArgs', () => {
+  it('parses `--port`', () => {
+    expect(parseArgs(['--port', '8930']).port).toEqual(8930)
+  })
+
+  it("throws if `--port` can't be converted to a number", () => {
+    expect(() => {
+      parseArgs(['--port', 'eight-nine-ten'])
+    }).toThrowErrorMatchingInlineSnapshot(`"\`--port\` must be a number"`)
+  })
+
+  it('returns an empty object if passed no args', () => {
+    const args = parseArgs([])
+    expect(args).toEqual({})
+  })
+})
+
+// it.todo('`fastifyServerOptions` configures the fastify server')
+// it.todo('returns a fastify server instance that can register plugins')
+// it.todo('fastifyServerOptions defaults to...')

--- a/packages/api-server/src/cliHandlers.ts
+++ b/packages/api-server/src/cliHandlers.ts
@@ -172,3 +172,6 @@ function coerceRootPath(path: string) {
 
   return `${prefix}${path}${suffix}`
 }
+
+// Temporarily here for local development while we test out this new function.
+export { createServer } from './createServer'

--- a/packages/api-server/src/createServer.ts
+++ b/packages/api-server/src/createServer.ts
@@ -1,0 +1,293 @@
+import fs from 'fs'
+import path from 'path'
+import { parseArgs as _parseArgs } from 'util'
+
+import fastifyUrlData from '@fastify/url-data'
+import c from 'ansi-colors'
+// @ts-expect-error can't be typed
+import { config } from 'dotenv-defaults'
+import fastify from 'fastify'
+import type { FastifyListenOptions, FastifyServerOptions } from 'fastify'
+import fastifyRawBody from 'fastify-raw-body'
+
+import { getConfig, getPaths } from '@redwoodjs/project-config'
+
+import {
+  loadFunctionsFromDist,
+  lambdaRequestHandler,
+} from './plugins/lambdaLoader'
+
+// Load .env files if they haven't already been loaded. This makes this file have an effectful import.
+// It's here and not in the function below so that users can access env vars before calling `createServer`.
+if (process.env.RWJS_CWD && !process.env.REDWOOD_ENV_FILES_LOADED) {
+  config({
+    path: path.join(getPaths().base, '.env'),
+    defaults: path.join(getPaths().base, '.env.defaults'),
+    multiline: true,
+  })
+}
+
+export interface CreateServerOptions {
+  /**
+   * The prefix for all routes. Defaults to `/`.
+   */
+  routePrefix?: string
+
+  /**
+   * Logger instance or options.
+   */
+  logger?: FastifyServerOptions['logger']
+
+  /**
+   * Options for the fastify server instance.
+   * Omitting logger here because we move it up.
+   */
+  fastifyServerOptions?: Omit<FastifyServerOptions, 'logger'>
+}
+
+/**
+ * Creates a server for api functions:
+ *
+ * ```js
+ * const server = await createServer({
+ *   logger,
+ *   routePrefix: '/api'
+ * })
+ *
+ * // Configure the returned fastify instance:
+ * server.register(myPlugin)
+ *
+ * // When ready, start the server:
+ * await server.start()
+ * ```
+ */
+export async function createServer(options: CreateServerOptions = {}) {
+  const { routePrefix, fastifyServerOptions } =
+    resolveCreateServerOptions(options)
+
+  // ------------------------
+  // Warn about `api/server.config.js`.
+  const serverConfigPath = path.join(
+    getPaths().base,
+    getConfig().api.serverConfig
+  )
+
+  if (fs.existsSync(serverConfigPath)) {
+    console.warn(
+      c.yellow(
+        [
+          '',
+          `Ignoring \`config\` and \`configureServer\` in api/server.config.js.`,
+          `Migrate them to api/src/server.{ts,js}`,
+          '',
+          `\`\`\`js title="api/src/server.{ts,js}"`,
+          '// Pass your config to `createServer`',
+          'const server = createServer({',
+          '  fastifyServerOptions: myFastifyConfig',
+          '})',
+          '',
+          '// Then inline your `configureFastify` logic:',
+          'server.register(myFastifyPlugin)',
+          '```',
+          '',
+        ].join('\n')
+      )
+    )
+  }
+
+  // ------------------------
+  // Initialize the fastify instance.
+  const server = fastify(fastifyServerOptions)
+
+  // ------------------------
+  // Register api/dist functions.
+  // TODO: this should probably all be in a plugin.
+  // TODO: isolate context.
+  server.register(fastifyUrlData)
+  await server.register(fastifyRawBody)
+
+  server.addContentTypeParser(
+    ['application/x-www-form-urlencoded', 'multipart/form-data'],
+    { parseAs: 'string' },
+    server.defaultTextParser
+  )
+
+  server.all(`${routePrefix}:routeName`, lambdaRequestHandler)
+  server.all(`${routePrefix}:routeName/*`, lambdaRequestHandler)
+
+  await loadFunctionsFromDist()
+
+  // ------------------------
+  // See https://github.com/redwoodjs/redwood/pull/4744.
+  server.addHook('onReady', (done) => {
+    process.send?.('ready')
+    done()
+  })
+
+  // ------------------------
+  // Just logging. The conditional here is to appease TS.
+  // `server.server.address()` can return a string, an AddressInfo object, or null.
+  // Note that the logging here ("Listening on...") seems to be duplicated, probably by `@redwoodjs/graphql-server`.
+  server.addHook('onListen', (done) => {
+    const addressInfo = server.server.address()
+
+    if (!addressInfo || typeof addressInfo === 'string') {
+      done()
+      return
+    }
+
+    server.log.info(
+      `Listening on ${c.magenta(
+        `http://${addressInfo.address}:${addressInfo.port}${routePrefix}`
+      )}`
+    )
+    done()
+  })
+
+  /**
+   * A wrapper around `fastify.listen` that handles `--port`, `REDWOOD_API_PORT` and [api].port in redwood.toml
+   *
+   * The order of precedence is:
+   * - `--port`
+   * - `REDWOOD_API_PORT`
+   * - [api].port in redwood.toml
+   */
+  function start(options: Omit<FastifyListenOptions, 'port' | 'host'> = {}) {
+    return server.listen(resolveStartOptions(options))
+  }
+
+  // TODO: type this.
+  // @ts-expect-error TODO
+  server.start = start
+
+  return server
+}
+
+type ResolvedCreateServerOptions = Required<
+  Omit<CreateServerOptions, 'logger' | 'fastifyServerOptions'> & {
+    fastifyServerOptions: FastifyServerOptions
+  }
+>
+
+export function resolveCreateServerOptions(
+  options: CreateServerOptions = {}
+): ResolvedCreateServerOptions {
+  options.logger ??= DEFAULT_CREATE_SERVER_OPTIONS.logger
+
+  // Set defaults.
+  const resolvedOptions: ResolvedCreateServerOptions = {
+    routePrefix:
+      options.routePrefix ?? DEFAULT_CREATE_SERVER_OPTIONS.routePrefix,
+
+    fastifyServerOptions: options.fastifyServerOptions ?? {
+      requestTimeout:
+        DEFAULT_CREATE_SERVER_OPTIONS.fastifyServerOptions.requestTimeout,
+      logger: options.logger ?? DEFAULT_CREATE_SERVER_OPTIONS.logger,
+    },
+  }
+
+  // Merge fastifyServerOptions.
+  resolvedOptions.fastifyServerOptions.requestTimeout ??=
+    DEFAULT_CREATE_SERVER_OPTIONS.fastifyServerOptions.requestTimeout
+  resolvedOptions.fastifyServerOptions.logger = options.logger
+
+  // Ensure the routePrefix begins and ends with a slash.
+  if (resolvedOptions.routePrefix.charAt(0) !== '/') {
+    resolvedOptions.routePrefix = `/${resolvedOptions.routePrefix}`
+  }
+
+  if (
+    resolvedOptions.routePrefix.charAt(
+      resolvedOptions.routePrefix.length - 1
+    ) !== '/'
+  ) {
+    resolvedOptions.routePrefix = `${resolvedOptions.routePrefix}/`
+  }
+
+  return resolvedOptions
+}
+
+type DefaultCreateServerOptions = Required<
+  Omit<CreateServerOptions, 'fastifyServerOptions'> & {
+    fastifyServerOptions: Pick<FastifyServerOptions, 'requestTimeout'>
+  }
+>
+
+export const DEFAULT_CREATE_SERVER_OPTIONS: DefaultCreateServerOptions = {
+  routePrefix: '/',
+  logger: {
+    level: process.env.NODE_ENV === 'development' ? 'debug' : 'warn',
+  },
+  fastifyServerOptions: {
+    requestTimeout: 15_000,
+  },
+}
+
+function resolveStartOptions(
+  options: Omit<FastifyListenOptions, 'port' | 'host'>
+): FastifyListenOptions {
+  const resolvedOptions: FastifyListenOptions = options
+
+  // Right now, `host` isn't configurable and is set based on `NODE_ENV` for Docker.
+  resolvedOptions.host =
+    process.env.NODE_ENV === 'production' ? '0.0.0.0' : '::'
+
+  const args = parseArgs()
+
+  if (args.port) {
+    resolvedOptions.port = args.port
+  } else {
+    if (process.env.REDWOOD_API_PORT === undefined) {
+      resolvedOptions.port = getConfig().api.port
+    } else {
+      resolvedOptions.port = parseInt(process.env.REDWOOD_API_PORT)
+    }
+  }
+
+  return resolvedOptions
+}
+
+/**
+ * The `args` parameter is just for testing. `_parseArgs` defaults to `process.argv`, which is what we want.
+ * This is also exported just for testing.
+ */
+export function parseArgs(args?: string[]) {
+  const options = {
+    port: {
+      type: 'string',
+      short: 'p',
+    },
+  }
+
+  const { values } = _parseArgs({
+    // When running Jest, `process.argv` is...
+    //
+    // ```js
+    // [
+    //    'path/to/node'
+    //    'path/to/jest.js'
+    //    'file/under/test.js'
+    // ]
+    // ```
+    //
+    // `parseArgs` strips the first two, leaving the third, which is interpreted as a positional argument.
+    // Which fails our options. We'd still like to be strict, but can't do it for tests.
+    strict: process.env.NODE_ENV === 'test' ? false : true,
+
+    ...(args && { args }),
+    // @ts-expect-error TODO
+    options,
+  })
+
+  const parsedArgs: { port?: number } = {}
+
+  if (values.port) {
+    parsedArgs.port = +values.port
+
+    if (isNaN(parsedArgs.port)) {
+      throw new Error('`--port` must be a number')
+    }
+  }
+
+  return parsedArgs
+}

--- a/packages/api-server/src/watch.ts
+++ b/packages/api-server/src/watch.ts
@@ -39,6 +39,7 @@ const argv = yargs(hideBin(process.argv))
 
 const rwjsPaths = getPaths()
 
+// ?
 dotenv.config({
   path: rwjsPaths.base,
 })

--- a/packages/cli/src/commands/experimental/setupServerFileHandler.js
+++ b/packages/cli/src/commands/experimental/setupServerFileHandler.js
@@ -84,12 +84,7 @@ export async function handler({ force, verbose }) {
           }
         },
       },
-      addApiPackages([
-        'fastify',
-        'chalk@4.1.2',
-        `@redwoodjs/fastify@${version}`,
-        `@redwoodjs/project-config@${version}`,
-      ]),
+      addApiPackages([`@redwoodjs/api-server@${version}`]),
       {
         task: () => {
           printTaskEpilogue(command, description, EXPERIMENTAL_TOPIC_ID)

--- a/packages/cli/src/commands/experimental/templates/server.ts.template
+++ b/packages/cli/src/commands/experimental/templates/server.ts.template
@@ -1,24 +1,15 @@
-import { parseArgs } from 'node:util'
-import path from 'path'
+/**
+ * This file only applies to serverful deploys.
+ */
 
-import chalk from 'chalk'
-import { config } from 'dotenv-defaults'
-import Fastify from 'fastify'
-
-import {
-  coerceRootPath,
-  redwoodFastifyWeb,
-  redwoodFastifyAPI,
-  redwoodFastifyGraphQLServer,
-  DEFAULT_REDWOOD_FASTIFY_CONFIG,
-} from '@redwoodjs/fastify'
-import { getPaths, getConfig } from '@redwoodjs/project-config'
+import { createServer } from '@redwoodjs/api-server'
+import { redwoodFastifyGraphQLServer } from '@redwoodjs/fastify'
 
 import directives from 'src/directives/**/*.{js,ts}'
 import sdls from 'src/graphql/**/*.sdl.{js,ts}'
 import services from 'src/services/**/*.{js,ts}'
 
-// Import if using RedwoodJS authentication
+// Don't forget to add these imports if you're using authentication:
 // import { authDecoder } from '@redwoodjs/<your-auth-provider>'
 // import { getCurrentUser } from 'src/lib/auth'
 
@@ -27,87 +18,34 @@ import { logger } from 'src/lib/logger'
 // Import if using RedwoodJS Realtime via `yarn rw exp setup-realtime`
 // import { realtime } from 'src/lib/realtime'
 
-async function serve() {
-  // Parse server file args
-  const { values: args } = parseArgs({
-    options: {
-      ['enable-web']: {
-        type: 'boolean',
-        default: false,
-      },
-    },
-  })
-  const { ['enable-web']: enableWeb } = args
-
-  // Load .env files
-  const redwoodProjectPaths = getPaths()
-  const redwoodConfig = getConfig()
-
-  const apiRootPath = enableWeb ? coerceRootPath(redwoodConfig.web.apiUrl) : ''
-  const port = enableWeb ? redwoodConfig.web.port : redwoodConfig.api.port
-
-  const tsServer = Date.now()
-
-  config({
-    path: path.join(redwoodProjectPaths.base, '.env'),
-    defaults: path.join(redwoodProjectPaths.base, '.env.defaults'),
-    multiline: true,
+async function main() {
+  const server = await createServer({
+    logger,
   })
 
-  console.log(chalk.italic.dim('Starting API and Web Servers...'))
-
-  // Configure Fastify
-  const fastify = Fastify({
-    ...DEFAULT_REDWOOD_FASTIFY_CONFIG,
-  })
-
-  if (enableWeb) {
-    await fastify.register(redwoodFastifyWeb)
-  }
-
-  await fastify.register(redwoodFastifyAPI, {
-    redwood: {
-      apiRootPath,
-    },
-  })
-
-  await fastify.register(redwoodFastifyGraphQLServer, {
-    // If authenticating, be sure to import and add in
-    // authDecoder,
-    // getCurrentUser,
-    loggerConfig: {
-      logger: logger,
-    },
-    graphiQLEndpoint: enableWeb ? '/.redwood/functions/graphql' : '/graphql',
+  await server.register(redwoodFastifyGraphQLServer, {
     sdls,
     services,
     directives,
+
+    graphiQLEndpoint: '/graphql',
+
     allowIntrospection: true,
     allowGraphiQL: true,
-    // Configure if using RedwoodJS Realtime
+
+    // TODO: see about removing this b/c this plugin should be able to use the fastify instance's logger
+    loggerConfig: {
+      logger,
+    },
+
+    // If authenticating, be sure to import and add in:
+    // authDecoder,
+    // getCurrentUser,
+    // Configure if using RedwoodJS Realtime:
     // realtime,
   })
 
-  // Start
-  fastify.listen({ port })
-
-  fastify.ready(() => {
-    console.log(chalk.italic.dim('Took ' + (Date.now() - tsServer) + ' ms'))
-    const on = chalk.magenta(`http://localhost:${port}${apiRootPath}`)
-    if (enableWeb) {
-      const webServer = chalk.green(`http://localhost:${port}`)
-      console.log(`Web server started on ${webServer}`)
-    }
-    const apiServer = chalk.magenta(`http://localhost:${port}`)
-    console.log(`API serving from ${apiServer}`)
-    console.log(`API listening on ${on}`)
-    const graphqlEnd = chalk.magenta(`${apiRootPath}graphql`)
-    console.log(`GraphQL function endpoint at ${graphqlEnd}`)
-  })
-
-  process.on('exit', () => {
-    fastify.close()
-  })
+  await server.start()
 }
 
-serve()
+main()

--- a/packages/cli/src/commands/experimental/templates/server.ts.template
+++ b/packages/cli/src/commands/experimental/templates/server.ts.template
@@ -1,48 +1,10 @@
-/**
- * This file only applies to serverful deploys.
- */
-
 import { createServer } from '@redwoodjs/api-server'
-import { redwoodFastifyGraphQLServer } from '@redwoodjs/fastify'
-
-import directives from 'src/directives/**/*.{js,ts}'
-import sdls from 'src/graphql/**/*.sdl.{js,ts}'
-import services from 'src/services/**/*.{js,ts}'
-
-// Don't forget to add these imports if you're using authentication:
-// import { authDecoder } from '@redwoodjs/<your-auth-provider>'
-// import { getCurrentUser } from 'src/lib/auth'
 
 import { logger } from 'src/lib/logger'
-
-// Import if using RedwoodJS Realtime via `yarn rw exp setup-realtime`
-// import { realtime } from 'src/lib/realtime'
 
 async function main() {
   const server = await createServer({
     logger,
-  })
-
-  await server.register(redwoodFastifyGraphQLServer, {
-    sdls,
-    services,
-    directives,
-
-    graphiQLEndpoint: '/graphql',
-
-    allowIntrospection: true,
-    allowGraphiQL: true,
-
-    // TODO: see about removing this b/c this plugin should be able to use the fastify instance's logger
-    loggerConfig: {
-      logger,
-    },
-
-    // If authenticating, be sure to import and add in:
-    // authDecoder,
-    // getCurrentUser,
-    // Configure if using RedwoodJS Realtime:
-    // realtime,
   })
 
   await server.start()

--- a/packages/cli/src/commands/serve.js
+++ b/packages/cli/src/commands/serve.js
@@ -99,7 +99,7 @@ export const builder = async (yargs) => {
           const { apiExperimentalServerFileHandler } = await import(
             './serveApiHandler.js'
           )
-          await apiExperimentalServerFileHandler()
+          await apiExperimentalServerFileHandler(argv)
         } else {
           const { apiServerHandler } = await import('./serveApiHandler.js')
           await apiServerHandler(argv)

--- a/packages/cli/src/commands/serveApiHandler.js
+++ b/packages/cli/src/commands/serveApiHandler.js
@@ -6,7 +6,10 @@ import execa from 'execa'
 import { createFastifyInstance, redwoodFastifyAPI } from '@redwoodjs/fastify'
 import { getPaths } from '@redwoodjs/project-config'
 
-export const apiExperimentalServerFileHandler = async () => {
+/**
+ * @returns doesn't pass args through
+ */
+export const apiExperimentalServerFileHandler = async (argv) => {
   logExperimentalHeader()
 
   await execa('yarn', ['node', path.join('dist', 'server.js')], {

--- a/packages/cli/src/commands/serveBothHandler.js
+++ b/packages/cli/src/commands/serveBothHandler.js
@@ -35,11 +35,26 @@ export const bothExperimentalServerFileHandler = async () => {
       shell: true,
     })
   } else {
-    await execa(
+    // need to start two processes...
+    execa('yarn', ['node', path.join('dist', 'server.js')], {
+      cwd: getPaths().api.base,
+      stdio: 'inherit',
+      shell: true,
+    })
+
+    execa(
       'yarn',
-      ['node', path.join('dist', 'server.js'), '--enable-web'],
+      [
+        'rw-web-server',
+        '--port',
+        argv.port,
+        '--socket',
+        argv.socket,
+        '--api-host',
+        argv.apiHost,
+      ],
       {
-        cwd: getPaths().api.base,
+        cwd: getPaths().base,
         stdio: 'inherit',
         shell: true,
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7818,6 +7818,7 @@ __metadata:
     fastify-raw-body: 4.2.2
     jest: 29.7.0
     lodash: 4.17.21
+    pino-abstract-transport: 1.1.0
     pretty-bytes: 5.6.0
     pretty-ms: 7.0.1
     qs: 6.11.2
@@ -28773,7 +28774,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pino-abstract-transport@npm:v1.1.0":
+"pino-abstract-transport@npm:1.1.0, pino-abstract-transport@npm:v1.1.0":
   version: 1.1.0
   resolution: "pino-abstract-transport@npm:1.1.0"
   dependencies:

--- a/yarn_patch_create_server.sh
+++ b/yarn_patch_create_server.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# For debugging:
+# set -x
+
+if [ -z "$RWFW_PATH" ]; then
+  echo "RWFW_PATH is not defined"
+  exit 1
+fi
+
+if [ -z "$REDWOOD_PROJECT_PATH" ]; then
+  echo "REDWOOD_PROJECT_PATH is not defined"
+  exit 1
+fi
+
+cd "$RWFW_PATH/packages/api-server" || exit 1
+yarn build
+
+cd "$REDWOOD_PROJECT_PATH" || exit 1
+yarn workspace api add @redwoodjs/api-server
+
+patchDirectory=$(
+  yarn patch @redwoodjs/api-server \
+  | grep -o "yarn patch-commit -s /private/var/folders/[a-zA-Z0-9/\-]*" \
+  | awk '{print $4}'
+)
+
+cp -r "$RWFW_PATH/packages/api-server/dist" "$patchDirectory"
+yarn patch-commit -s "$patchDirectory"
+yarn
+
+cat "$RWFW_PATH/packages/cli/src/commands/experimental/templates/server.ts.template" > "$REDWOOD_PROJECT_PATH/api/src/server.ts"
+
+git add .
+git commit -m "chore(createServer): patch @redwoodjs/api-server"


### PR DESCRIPTION
- renames routePrefix back to apiRootPath for now
- puts function registering logic into a plugin
- uses console log instead of server.log
- updates tests
- updates template 